### PR TITLE
Fixed invalid path in build script and updated buildroot and mosquitto

### DIFF
--- a/tiny-mosquitto/README.md
+++ b/tiny-mosquitto/README.md
@@ -12,7 +12,7 @@ a minimal runtime only docker encapsulation of the mosquitto mqtt broker availab
 
 currently uses http://mosquitto.org/files/source/mosquitto-1.3.5.tar.gz
 
-this is built using buildroot v14.11 http://buildroot.uclibc.org/ in order to make the image small.
+this is built using buildroot v14.05 http://buildroot.uclibc.org/ in order to make the image small.
 
 the docker image was built with instructions from 
 

--- a/tiny-mosquitto/README.md
+++ b/tiny-mosquitto/README.md
@@ -1,4 +1,4 @@
-mosquitto-lite
+tiny-mosquitto
 ==============
 
 this file is available at
@@ -8,11 +8,11 @@ https://github.com/lexlapax/Dockerfiles/blob/master/tiny-mosquitto/README.md
 
 description
 -----------
-a minimal runtime only docker encapsulation of the mosquitto mqtt broker available at  http://mosquitto.org
+a minimal runtime only docker encapsulation of the mosquitto mqtt broker available at http://mosquitto.org
 
-currently uses http://mosquitto.org/files/source/mosquitto-1.2.3.tar.gz
+currently uses http://mosquitto.org/files/source/mosquitto-1.3.5.tar.gz
 
-this is built using buildroot http://buildroot.uclibc.org/ in order to make the image small.
+this is built using buildroot v14.11 http://buildroot.uclibc.org/ in order to make the image small.
 
 the docker image was built with instructions from 
 

--- a/tiny-mosquitto/buildimage.sh
+++ b/tiny-mosquitto/buildimage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 export IMAGENAME=tinymosquitto
-export BUILDROOTVER=2013.11
+export BUILDROOTVER=2014.11
 
 
 mkdir ~/src
@@ -9,20 +9,20 @@ cd ~/src
 wget http://buildroot.uclibc.org/downloads/buildroot-$BUILDROOTVER.tar.gz
 tar -xzvf buildroot-$BUILDROOTVER.tar.gz
 git clone https://github.com/lexlapax/Dockerfiles
-cp -r Dockerfiles/mosquitto-lite/package/mosquito buildroot-$BUILDROOTVER/package/
-cp Dockerfiles/mosquitto-lite/buildroot.config buildroot-$BUILDROOTVER/.config
+cp -r Dockerfiles/tiny-mosquitto/buildroot/package/mosquitto buildroot-$BUILDROOTVER/package/
+cp Dockerfiles/tiny-mosquitto/buildroot/buildroot.config buildroot-$BUILDROOTVER/.config
 cd buildroot-$BUILDROOTVER
 make all
 # wait a really long time while it builds everything including the toolchain
 cd output/images
 mkdir extra extra/sbin extra/etc
 touch extra/sbin/init extra/etc/resolv.conf
-cp root.tar fixup.tar
+cp rootfs.tar fixup.tar
 tar rvf fixup.tar -C extra .
 
 # docker steps
-docker import - tinyimage < fixup.tar
-cd ../../../Dockerfiles/mosquitto-lite
+sudo docker import - tinyimage < fixup.tar
+cd ../../../Dockerfiles/tiny-mosquitto
 
 sed -i.bak -e "s/FROM lapax\/buildroot:mosquitto/FROM tinyimage/g" Dockerfile
 sudo docker build -t $IMAGENAME .

--- a/tiny-mosquitto/buildroot/package/mosquitto/mosquitto.mk
+++ b/tiny-mosquitto/buildroot/package/mosquitto/mosquitto.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-MOSQUITTO_VERSION = 1.2.3
+MOSQUITTO_VERSION = 1.3.5
 MOSQUITTO_SOURCE = mosquitto-$(MOSQUITTO_VERSION).tar.gz
 MOSQUITTO_SITE = http://mosquitto.org/files/source/$(MOSQUITTO_SOURCE)
 MOSQUITTO_DEPENDENCIES = openssl zlib


### PR DESCRIPTION
Verified to be working with updated libraries:
a) Mosquitto v1.3.5
b) buildroot v14.05

Fixed changed in path location in buildimage.sh
