### PR TITLE
Pull forward to mosquitto 1.4.2 as of May 4, 2015

### DIFF
--- a/tiny-mosquitto/buildroot/package/mosquitto/mosquitto.mk
+++ b/tiny-mosquitto/buildroot/package/mosquitto/mosquitto.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-MOSQUITTO_VERSION = 1.3.5
+MOSQUITTO_VERSION = 1.4.2
 MOSQUITTO_SOURCE = mosquitto-$(MOSQUITTO_VERSION).tar.gz
 MOSQUITTO_SITE = http://mosquitto.org/files/source/$(MOSQUITTO_SOURCE)
 MOSQUITTO_DEPENDENCIES = openssl zlib


### PR DESCRIPTION
See release notes at http://mosquitto.org/2015/05/version-1-4-2-released/

"This is a bugfix release", but see also the release notes for 1.4.1 (bugfix and security) and 1.4.0 (features).
